### PR TITLE
Refactor styles, add variable to adjust heading color

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,14 @@ For compatibility with previous model version use `3.x.x` version of the compone
 
 Custom property | Description | Default
 ----------------|-------------|----------
-`--api-headers-document-title-border-color` | Border color of the title area | `#e5e5e5`
-`--api-headers-document-toggle-view-color` | Color of the toggle button | `--arc-toggle-view-icon-color` or `rgba(0, 0, 0, 0.74)`
-`--api-headers-document-toggle-view-hover-color` | Color of the toggle button when hovering. Please, mind that hover is not available on all devices. | `--arc-toggle-view-icon-hover-color` or `rgba(0, 0, 0, 0.88)`
-`--toggle-button-color`  |   |  ``
-`--toggle-button-font-weight`  |   |  ``
-`-no-info-message-font-style` |   |  `italic`
+`--arc-font-subhead-color` | Color of the collapsible section title | ``
+`--arc-font-subhead-font-size` | Font size of the collapsible section title | ``
+`--arc-font-subhead-line-height` | Line height of the collapsible section title | ``
+`--arc-font-subhead-narrow-font-size` | Font size of the collapsible section title in mobile-friendly view | ``
+`--api-parameters-document-title-border-color` | Border color of the collapsible section title area | `#e5e5e5`
+`--no-info-message-font-style` |   |  `italic`
 `--no-info-message-font-size`  |   |  `16px`
 `--no-info-message-color`  |   |  `rgba(0, 0, 0, 0.74)`
-`--api-headers-document-title-narrow-font-size` |   | `17px`
 
 ## Usage
 
@@ -88,4 +87,4 @@ npm test
 
 ## API components
 
-This components is a part of [API components ecosystem](https://elements.advancedrestclient.com/)
+This component is a part of [API components ecosystem](https://elements.advancedrestclient.com/)

--- a/src/ApiHeadersDocument.js
+++ b/src/ApiHeadersDocument.js
@@ -55,7 +55,7 @@ export class ApiHeadersDocument extends LitElement {
       transform: rotateZ(-180deg);
     }
 
-    .headers-title {
+    .heading3 {
       flex: 1;
       flex-basis: 0.000000001px;
       white-space: nowrap;
@@ -66,14 +66,14 @@ export class ApiHeadersDocument extends LitElement {
       line-height: var(--arc-font-subhead-line-height);
     }
 
+    :host([narrow]) .heading3 {
+      font-size: var(--api-headers-document-title-narrow-font-size, var(--arc-font-subhead-narrow-font-size, 17px));
+    }
+
     .no-info {
       font-style: var(--no-info-message-font-style, italic);
       font-size: var(--no-info-message-font-size, 16px);
       color: var(--no-info-message-color, rgba(0, 0, 0, 0.74));
-    }
-
-    :host([narrow]) .headers-title {
-      font-size: var(--api-headers-document-title-narrow-font-size, 17px);
     }
 
     .icon {
@@ -94,7 +94,7 @@ export class ApiHeadersDocument extends LitElement {
       title="Toggle headers details"
       ?data-opened="${opened}"
     >
-      <div class="headers-title" role="heading" aria-level="${headerLevel}">Headers</div>
+      <div class="heading3" role="heading" aria-level="${headerLevel}">Headers</div>
       <div class="title-area-actions">
         <anypoint-button class="toggle-button" ?compatibility="${compatibility}">
           ${this._computeToggleActionLabel(opened)}

--- a/src/ApiHeadersDocument.js
+++ b/src/ApiHeadersDocument.js
@@ -57,10 +57,7 @@ export class ApiHeadersDocument extends LitElement {
 
     .heading3 {
       flex: 1;
-      flex-basis: 0.000000001px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      color: var(--arc-font-subhead-color);
       font-size: var(--arc-font-subhead-font-size);
       font-weight: var(--arc-font-subhead-font-weight);
       line-height: var(--arc-font-subhead-line-height);

--- a/src/ApiHeadersDocument.js
+++ b/src/ApiHeadersDocument.js
@@ -32,12 +32,9 @@ export class ApiHeadersDocument extends LitElement {
       display: flex;
       flex-direction: row;
       align-items: center;
+      border-bottom: 1px var(--api-headers-document-title-border-color, var(--api-parameters-document-title-border-color, #e5e5e5)) solid;
       cursor: pointer;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
       user-select: none;
-      border-bottom: 1px var(--api-headers-document-title-border-color, #e5e5e5) solid;
       transition: border-bottom-color 0.15s ease-in-out;
     }
 

--- a/test/api-headers-document.test.js
+++ b/test/api-headers-document.test.js
@@ -112,7 +112,7 @@ describe('ApiHeadersDocument', () => {
 
         it('Narrow style is applied to the title', async () => {
           element.style.setProperty('--arc-font-subhead-narrow-font-size', '16px');
-          const title = element.shadowRoot.querySelector('.headers-title');
+          const title = element.shadowRoot.querySelector('.heading3');
           const { fontSize } = getComputedStyle(title);
           assert.equal(fontSize, '16px');
         });

--- a/test/api-headers-document.test.js
+++ b/test/api-headers-document.test.js
@@ -111,7 +111,7 @@ describe('ApiHeadersDocument', () => {
         });
 
         it('Narrow style is applied to the title', async () => {
-          element.style.setProperty('--api-headers-document-title-narrow-font-size', '16px');
+          element.style.setProperty('--arc-font-subhead-narrow-font-size', '16px');
           const title = element.shadowRoot.querySelector('.headers-title');
           const { fontSize } = getComputedStyle(title);
           assert.equal(fontSize, '16px');


### PR DESCRIPTION
1. Change `.headers-title` to `.heading3` and adjust styles (see also https://github.com/advanced-rest-client/api-body-document/pull/19).
2. Use `--api-parameters-document-title-border-color` for all collapsible sections to unify the appearance with single variable (see also advanced-rest-client/api-method-documentation#36).
3. Add `--arc-font-subhead-color` to allow heading color modification.