### PR TITLE
[W-11117709] Headers examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-headers-document",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-headers-document",
   "description": "Documentation component for API headers based on AMF data model",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiHeadersDocument.js
+++ b/src/ApiHeadersDocument.js
@@ -107,6 +107,7 @@ export class ApiHeadersDocument extends LitElement {
             ?narrow="${narrow}"
             ?graph="${graph}"
             noExamplesActions
+            noMainExample
           ></api-type-document>` :
           html`<p class="no-info">Headers are not required by this endpoint</p>`}
       </anypoint-collapse>


### PR DESCRIPTION
Bug: headers examples should be at under each header and not on top of the section
Fix: enable noMainExample for api-type-document